### PR TITLE
Improve button style

### DIFF
--- a/extension/main.js
+++ b/extension/main.js
@@ -25,7 +25,8 @@ function isButtonInsertedGithubGist(url) {
 	{
     const runGistInImageJdotJS = document.createElement('a');
     runGistInImageJdotJS.innerHTML = 'Run in ImageJ.JS';
-    runGistInImageJdotJS.setAttribute('class', 'btn btn-sm ');
+    runGistInImageJdotJS.style.color = "#0366d6";
+    runGistInImageJdotJS.setAttribute('class', 'btn btn-sm');
     runGistInImageJdotJS.setAttribute('target','_blank');
     runGistInImageJdotJS.setAttribute('href', "https://ij.imjoy.io/?run="+buttons[b].href.replace("https://gist.github.com/","https://gist.githubusercontent.com/"));
     try {
@@ -48,7 +49,8 @@ function isButtonInsertedGithub(url) {
 	{
     const runGistInImageJdotJS = document.createElement('a');
     runGistInImageJdotJS.innerHTML = 'Run in ImageJ.JS';
-    runGistInImageJdotJS.setAttribute('class', 'btn btn-sm ');
+    runGistInImageJdotJS.style.color = "#0366d6";
+    runGistInImageJdotJS.setAttribute('class', 'btn js-update-url-with-hash btn-sm BtnGroup-item');
     runGistInImageJdotJS.setAttribute('target','_blank');
     runGistInImageJdotJS.setAttribute('href', 'https://ij.imjoy.io/?run='+url);
     try {
@@ -69,11 +71,16 @@ function isButtonInsertedZenodo(url) {
 	    imgUrl = buttons[i].href;
 	    imgUrl = imgUrl.replace('?download=1','');
 	    if (imgUrl.toLowerCase().endsWith('.tif')) {
-	      const openInImageJdotJS = document.createElement('a');
-	      openInImageJdotJS.innerHTML = 'Open in ImageJ.JS';
+        const openInImageJdotJS = document.createElement('a');
+        const imagejIcon = document.createElement('img');
+        imagejIcon.src = 'https://ij.imjoy.io/assets/icons/chrome/chrome-extensionmanagementpage-48-48.png';
+        imagejIcon.style.height = '16px';
+        openInImageJdotJS.appendChild(imagejIcon);
+        openInImageJdotJS.innerHTML += 'Open in ImageJ.JS';
+        openInImageJdotJS.style.color = "#0366d6";
 	      openInImageJdotJS.setAttribute('class', 'btn btn-xs btn-default');
 	      openInImageJdotJS.setAttribute('target','_blank');
-	      openInImageJdotJS.setAttribute('href', 'https://ij.imjoy.io/?open='+imgUrl);
+        openInImageJdotJS.setAttribute('href', 'https://ij.imjoy.io/?open='+imgUrl);
 	      try {
 	        buttons[i].parentNode.appendChild(openInImageJdotJS);
 	      } catch (error) {


### PR DESCRIPTION
This PR improve the buttons: 1) add a small imagej icon for zenodo 2) change button text color to blue so they can standout 3) fix the style for github files


## Zenodo
<img width="769" alt="Screenshot 2020-10-09 at 23 55 41" src="https://user-images.githubusercontent.com/478667/95634795-02e18c80-0a8b-11eb-82ea-b84ea43baa3d.png">

## Github
<img width="822" alt="Screenshot 2020-10-09 at 23 56 49" src="https://user-images.githubusercontent.com/478667/95634840-1ee52e00-0a8b-11eb-8296-951735d3e54c.png">

## Gist
<img width="1015" alt="Screenshot 2020-10-09 at 23 57 38" src="https://user-images.githubusercontent.com/478667/95634897-3d4b2980-0a8b-11eb-966b-3753e46462e0.png">
